### PR TITLE
[config] improve the first time setup experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,16 @@ npm install
 
 ### Create a `config.js` file
 
-Next, you will need to set up your `config.js` in the root of video captain. It should be of the form:
+Next, you will need to set up your `config.js` in the root of video captain. For flexibility, you may adjust the location of the config file by setting the `VC_CONFIG` envar to the location of your file.
+
+The file should be of the form:
 
 ```js
 module.exports = {
-  mountPath: '/media/videos/',      // [REQUIRED] path to the folder you want to serve videos from
-  port: process.env.PORT || 8080,   // [OPTIONAL] the port you want the server to host at (default 5555)
-  settingsConfig: {                 // [OPTIONAL] make some custom preferences for how the system runs
-    clientCanShutdownServer: true,  // allow setting on client side to shutdown server exits with (200) status
+  mediaRoot: '/path/to/media/videos/',  // [REQUIRED] path to the root media folder you want to serve videos from
+  port: process.env.PORT || 8080,       // [OPTIONAL] the port you want the server to host at (default 5555)
+  settingsConfig: {                     // [OPTIONAL] make some custom preferences for how the system runs
+    clientCanShutdownServer: true,      // allow setting on client side to shutdown server exits with (200) status
   }
 }
 ```

--- a/components/collection-browser.js
+++ b/components/collection-browser.js
@@ -22,9 +22,15 @@
       this.collection = await fetch(this.boundEndpoint)
       return this.collection
     }
-    
+
     renderLoadingState () {
-      this.innerHTML = `<br/><br/><br/><br/><br/>Loading...<span class="hack-episode-alignment"></span>`
+      this.innerHTML = `<br/><br/><br/><br/><br/><div class="browser">Loading...<span class="hack-episode-alignment"></span></div>`
+    }
+
+    renderMediaMissingState () {
+      this.innerHTML = `<br/><br/><br/><br/><br/><div class="browser">
+        No playable media found. Add some videos to your <code>mediaRoot</code> directory and restart VideoCaptain to see them here.
+      </div>`
     }
     
     render () {
@@ -44,6 +50,7 @@
           }
         `;
       } else {
+        if (!collection.length) return this.renderMediaMissingState()
         this.innerHTML = `
           <div class="browser">
             ${_(collection.map(([ show, episodes ]) => `

--- a/mediaFiles.js
+++ b/mediaFiles.js
@@ -1,7 +1,8 @@
 const fs = require('fs')
 const path = require('path')
-const { mountPath } = require('./config')
+const { mountPath, mediaRoot } = require('./config')
 
+const mediaRootPath = mediaRoot || mountPath // mountPath is deprecated, but we keep it for backwards compatibility
 
 const isSupportedMediaType = x => ['.m4v', '.mp4'].reduce((a,c) => a || x.endsWith(c), false)
 
@@ -11,13 +12,13 @@ function walkMediaFiles(dir, files = []) {
       files = walkMediaFiles(path.join(dir, file), files);
     }
     else if (isSupportedMediaType(file)) {
-      files.push({file, folder: dir.replace(mountPath, '')});
+      files.push({file, folder: dir.replace(mediaRootPath, '')});
     }
   });
   return files;
 };
 
-const videoFiles = walkMediaFiles(mountPath)
+const videoFiles = walkMediaFiles(mediaRootPath)
 
 const organizedVideoFiles = {}
 videoFiles.forEach(video => {
@@ -30,7 +31,7 @@ const sortedVideoFiles = [
   ...Object.keys(organizedVideoFiles)
     .sort().filter(k => !!k)
     .map(show => [  show, organizedVideoFiles[show] ]), 
-  [ 'Other Shows', organizedVideoFiles[''] ] 
-];
+    organizedVideoFiles[''] ? [ 'Other Shows', organizedVideoFiles[''] ] : undefined
+].filter(Boolean);
 
 module.exports = { videoFiles, organizedVideoFiles, sortedVideoFiles }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "video-captain",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Serve up a folder of video files for your pleasure of viewing on a locally hosted server.",
   "main": "server.js",
   "scripts": {


### PR DESCRIPTION
Resolves #12

- Errors are now helpful (telling you how to resolve them)
- if there is no media found in a the media root folder, then the client explains how to show content
- deprecated `mountPath` and added `mediaRoot` for better mental model (with backwards compatibility)
- You can now optionally set `VC_CONFIG` envar to specify where to look for the `config.js` file

### Examples

If you run `npm start` before creating the `config.js` file, you will get this error (with an `exit(20)`):

```
No config file found. Expected to find a config file at "${configPath}", but no such file exists. See https://github.com/kyle-west/video-captain#create-a-configjs-file for details on how to set one up.
```

If you run `npm start` with an invalid `mediaRoot`/`mountPath`, you will get this error (with an `exit(30)`):

```
Expected to find a media root at "${mediaRootPath}", but no such folder exists. See https://github.com/kyle-west/video-captain#create-a-configjs-file for details.
```

If all the above are valid but there is no content to serve, the client shows the following. Previously, this would simply show the loading state forever (as demonstrated in #12)

<img width="1039" alt="Screenshot 2023-01-30 at 8 04 39 AM" src="https://user-images.githubusercontent.com/18150457/215517064-340047d5-1d80-407c-ac77-6ad411efda02.png">
